### PR TITLE
Node++ 2.3.1

### DIFF
--- a/lib/npp.h
+++ b/lib/npp.h
@@ -69,7 +69,7 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <limits.h>     /* INT_MAX */
-#include <cinttypes>
+//#include <cinttypes>
 
 #ifndef _WIN32
 #include <unistd.h>

--- a/lib/npp.h
+++ b/lib/npp.h
@@ -100,7 +100,7 @@ typedef char                            bool;
    macros
 -------------------------------------------------------------------------- */
 
-#define NPP_VERSION                     "2.3.0"
+#define NPP_VERSION                     "2.3.1"
 
 
 #ifndef FALSE

--- a/lib/npp_lib.c
+++ b/lib/npp_lib.c
@@ -7384,7 +7384,8 @@ int64_t npp_open_read_file(const char *fname, void **data)
     human_size_t hs;
     human_size(size, &hs);
 
-    DBG("File size: %" PRId64 " bytes (%" PRId64 " KiB / %d MiB / %d GiB)", size, hs.kib, hs.mib, hs.gib);
+//    DBG("File size: %" PRId64 " bytes (%" PRId64 " KiB / %d MiB / %d GiB)", size, hs.kib, hs.mib, hs.gib);
+    DBG("File size: %ld bytes (%ld KiB / %d MiB / %d GiB)", size, hs.kib, hs.mib, hs.gib);
 
 #endif
 


### PR DESCRIPTION
Drop inttypes as it causes compatibility issues with older compilers on Linux.