### PR TITLE
Node++ 3.1

### DIFF
--- a/lib/npp.h
+++ b/lib/npp.h
@@ -722,6 +722,10 @@ typedef char                            QSVAL_TEXT[NPP_QSBUF_TEXT];
 #define NPP_SESSID_LEN                      20              /* session id length (15 gives ~ 89 bits of entropy) */
 #endif
 
+#ifndef NPP_PHP_SESSID_LEN
+#define NPP_PHP_SESSID_LEN                  31              /* PHP session id length */
+#endif
+
 #ifndef NPP_CSRFT_LEN
 #define NPP_CSRFT_LEN                       15              /* CSRF token length */
 #endif
@@ -1637,13 +1641,11 @@ typedef struct {
     int      static_res;                            /* static resource index in M_stat */
 #ifdef NPP_PHP
     bool     php;
+    char     php_sessid[NPP_PHP_SESSID_LEN+1];
 #endif
     time_t   last_activity;
 #ifdef NPP_FD_MON_POLL
     int      pi;                                    /* M_pollfds array index */
-#endif
-#ifdef NPP_FD_MON_EPOLL
-//    bool     epoll_out_ready;
 #endif
 #ifdef NPP_ASYNC
     char     service[NPP_SVC_NAME_LEN+1];

--- a/lib/npp.h
+++ b/lib/npp.h
@@ -976,6 +976,7 @@ typedef char                            QSVAL_TEXT[NPP_QSBUF_TEXT];
 #define STATIC_SOURCE_RES               '1'
 #define STATIC_SOURCE_RESMIN            '2'
 #define STATIC_SOURCE_SNIPPETS          '3'
+#define STATIC_SOURCE_PHP               '4'
 
 
 #define NPP_RES_CACHE_DEF_TRESHOLD      16777216                /* 16 MiB */
@@ -1037,6 +1038,7 @@ typedef char                            QSVAL_TEXT[NPP_QSBUF_TEXT];
 #define NPP_CONTENT_TYPE_JPG            'j'
 #define NPP_CONTENT_TYPE_ICO            'i'
 #define NPP_CONTENT_TYPE_PNG            'p'
+#define NPP_CONTENT_TYPE_PHP            'P'
 #define NPP_CONTENT_TYPE_WOFF2          'w'
 #define NPP_CONTENT_TYPE_SVG            'v'
 //#define NPP_CONTENT_TYPE_JSON           'o'
@@ -1219,7 +1221,11 @@ typedef struct {
     char resmin[256];
     char snippets[256];
     char required_auth_level;
-    int  index_present;
+    int  index_html_present;
+#ifdef NPP_PHP
+    char php[256];
+    int  index_php_present;
+#endif
 } npp_host_t;
 
 
@@ -1537,6 +1543,7 @@ typedef struct {
     unsigned was_read;                              /* request bytes read so far */
     /* parsed HTTP request starts here */
     char     uri[NPP_MAX_URI_LEN+1];                /* requested URI string */
+    char     uri_no_qs[NPP_MAX_URI_LEN+1];          /* requested URI without query string */
     char     resource[NPP_MAX_RESOURCE_LEN+1];      /* from URI (REQ0) */
 #if NPP_RESOURCE_LEVELS > 1
     char     path1[NPP_MAX_RESOURCE_LEN+1];          /* from URI -- level 1 */
@@ -1628,6 +1635,9 @@ typedef struct {
     int      ssl_err;
     int      si;                                    /* session index */
     int      static_res;                            /* static resource index in M_stat */
+#ifdef NPP_PHP
+    bool     php;
+#endif
     time_t   last_activity;
 #ifdef NPP_FD_MON_POLL
     int      pi;                                    /* M_pollfds array index */

--- a/lib/npp.h
+++ b/lib/npp.h
@@ -1931,7 +1931,13 @@ extern "C" {
     void npp_eng_read_blocked_ips(void);
     void npp_eng_read_allowed_ips(void);
     void npp_eng_block_ip(const char *value, bool autoblocked);
+
+#ifdef NPP_CPP_STRINGS
+    bool npp_eng_is_uri(const std::string& uri);
+#else
     bool npp_eng_is_uri(const char *uri);
+#endif
+
     void npp_eng_out_check(const char *str);
     void npp_eng_out_check_realloc(const char *str);
     void npp_eng_out_check_realloc_bin(const char *data, int len);

--- a/lib/npp.h
+++ b/lib/npp.h
@@ -100,7 +100,7 @@ typedef char                            bool;
    macros
 -------------------------------------------------------------------------- */
 
-#define NPP_VERSION                     "3.0.1"
+#define NPP_VERSION                     "3.1.0"
 
 
 #ifndef FALSE
@@ -1069,7 +1069,7 @@ typedef char                            QSVAL_TEXT[NPP_QSBUF_TEXT];
 #define REQ_TAB                         (G_connections[G_ci].ua_type==NPP_UA_TYPE_TAB)
 #define REQ_MOB                         (G_connections[G_ci].ua_type==NPP_UA_TYPE_MOB)
 #define URI(uri)                        npp_eng_is_uri(uri)
-#define REQ(res)                        (0==strcmp(G_connections[G_ci].resource, res))
+//#define REQ(res)                        (0==strcmp(G_connections[G_ci].resource, res))
 #define REQ0(res)                       (0==strcmp(G_connections[G_ci].resource, res))
 #define REQ1(res)                       (0==strcmp(G_connections[G_ci].path1, res))
 #define REQ2(res)                       (0==strcmp(G_connections[G_ci].path2, res))

--- a/lib/npp_eng_app.c
+++ b/lib/npp_eng_app.c
@@ -5079,7 +5079,11 @@ static void process_php()
     STRM("REQUEST_METHOD=%s ", G_connections[G_ci].method);
 
     if ( G_connections[G_ci].in_cookie[0] )
+#ifdef NPP_PHP_ALL_COOKIES
         STRM("HTTP_COOKIE=\"%s\" ", npp_filter_cookie(G_connections[G_ci].in_cookie));
+#else
+        STRM("HTTP_COOKIE=\"PHPSESSID=%s\" ", npp_filter_strict(G_connections[G_ci].php_sessid));
+#endif
 
     if ( REQ_GET && qs && *(qs+1) != EOS )
     {

--- a/lib/npp_eng_app.c
+++ b/lib/npp_eng_app.c
@@ -8071,8 +8071,14 @@ void npp_eng_block_ip(const char *value, bool autoblocked)
            | logout      | T
            | logout?qs=1 | T
 -------------------------------------------------------------------------- */
+#ifdef NPP_CPP_STRINGS
+bool npp_eng_is_uri(const std::string& uri_)
+{
+    const char *uri = uri_.c_str();
+#else
 bool npp_eng_is_uri(const char *uri)
 {
+#endif
     const char *u = uri;
 
     if ( uri[0] == '/' )

--- a/lib/npp_eng_app.c
+++ b/lib/npp_eng_app.c
@@ -6155,6 +6155,7 @@ static void reset_connection(int ci, char new_state)
     G_connections[ci].static_res = NPP_NOT_STATIC;
 #ifdef NPP_PHP
     G_connections[ci].php = FALSE;
+    G_connections[ci].php_sessid[0] = EOS;
 #endif
     G_connections[ci].out_ctype = NPP_CONTENT_TYPE_HTML;
     G_connections[ci].ctypestr[0] = EOS;
@@ -7312,6 +7313,7 @@ static int set_http_req_val(const char *label, const char *value)
                 G_connections[G_ci].cookie_in_a[NPP_SESSID_LEN] = EOS;
             }
         }
+
         if ( NULL != (p=(char*)strstr(value, "ls=")) )   /* logged in sessid present? */
         {
             p += 3;
@@ -7321,6 +7323,27 @@ static int set_http_req_val(const char *label, const char *value)
                 G_connections[G_ci].cookie_in_l[NPP_SESSID_LEN] = EOS;
             }
         }
+#ifdef NPP_PHP
+        if ( NULL != (p=(char*)strstr(value, "PHPSESSID=")) )
+        {
+            p += 10;
+
+            char *end = (char*)strchr(p, ';');
+
+            int len;
+
+            if ( end )
+                len = end - p;
+            else
+                len = strlen(p);
+
+            if ( len <= NPP_PHP_SESSID_LEN )
+            {
+                strncpy(G_connections[G_ci].php_sessid, p, len);
+                G_connections[G_ci].php_sessid[len] = EOS;
+            }
+        }
+#endif  /* NPP_PHP */
     }
     else if ( 0==strcmp(ulabel, "REFERER") )
     {

--- a/lib/npp_eng_app.c
+++ b/lib/npp_eng_app.c
@@ -5078,6 +5078,9 @@ static void process_php()
     STRM("SCRIPT_FILENAME=%s/res/%s ", G_appdir, G_connections[G_ci].uri_no_qs);
     STRM("REQUEST_METHOD=%s ", G_connections[G_ci].method);
 
+    if ( G_connections[G_ci].in_cookie[0] )
+        STRM("HTTP_COOKIE=\"%s\" ", npp_filter_cookie(G_connections[G_ci].in_cookie));
+
     if ( REQ_GET && qs && *(qs+1) != EOS )
     {
         STRM("QUERY_STRING=\"%s\" ", npp_filter_qs(qs+1));
@@ -5135,6 +5138,11 @@ static void process_php()
         {
             DBG("Redirecting to [%s]", line+10);
             RES_LOCATION(line+10);
+        }
+        else if ( (line[0]=='S' || line[0]=='s') && 0==strncmp(line+1, "et-", 3) && line[5]=='o' )
+        {
+            DBG("Setting cookie [%s]", line+12);
+            npp_lib_res_header("Set-Cookie", line+12);
         }
     }
 

--- a/lib/npp_eng_app.c
+++ b/lib/npp_eng_app.c
@@ -206,7 +206,10 @@ static unsigned     M_last_call_id=0;               /* counter */
 static char         *M_async_shm=NULL;              /* shared memory address */
 #endif  /* NPP_ASYNC */
 
-static int          M_index_present=-1;             /* index.html present in res? */
+static int          M_index_html_present=-1;        /* index.html present in res? */
+#ifdef NPP_PHP
+static int          M_index_php_present=-1;         /* index.php present in res? */
+#endif
 
 
 
@@ -222,9 +225,9 @@ static void http2_parse_frame(int bytes);
 static void http2_add_frame(unsigned char type);
 #endif  /* NPP_HTTP2 */
 static void set_state(int bytes, bool secure);
-static void respond_to_expect();
-static void log_proc_time();
-static void log_request();
+static void respond_to_expect(void);
+static void log_proc_time(void);
+static void log_request(void);
 static void close_connection(int ci, bool update_first_free);
 static bool init(int argc, char **argv);
 #ifdef NPP_FD_MON_SELECT
@@ -235,11 +238,12 @@ static bool ip_blocked(const char *addr);
 static bool ip_allowed(const char *addr);
 static int  first_free_stat(void);
 static bool read_resources(bool first_scan);
-static int  is_static_res();
-static void process_request();
-static void gen_response_header();
+static int  is_static_res(void);
+static void process_request(void);
+static void process_php(void);
+static void gen_response_header(void);
 static void print_content_type(char type);
-static bool a_session_ok();
+static bool a_session_ok(void);
 static void close_old_conn(void);
 static void uses_close_timeouted(void);
 static void close_uses(int si, int ci);
@@ -4183,12 +4187,24 @@ static bool read_files(const char *host, int host_id, const char *directory, cha
                 if ( 0==strcmp(M_statics[i].name, "index.html") )
                 {
                     if ( host_id == 0 )
-                        M_index_present = -1;
+                        M_index_html_present = -1;
 #ifdef NPP_MULTI_HOST
                     else
-                        G_hosts[host_id].index_present = -1;
+                        G_hosts[host_id].index_html_present = -1;
 #endif
                 }
+
+#ifdef NPP_PHP
+                if ( 0==strcmp(M_statics[i].name, "index.php") )
+                {
+                    if ( host_id == 0 )
+                        M_index_php_present = -1;
+#ifdef NPP_MULTI_HOST
+                    else
+                        G_hosts[host_id].index_php_present = -1;
+#endif
+                }
+#endif  /* NPP_PHP */
 
 #ifdef NPP_MULTI_HOST
                 M_statics[i].host[0] = EOS;
@@ -4483,12 +4499,23 @@ static bool read_files(const char *host, int host_id, const char *directory, cha
                 if ( 0==strcmp(M_statics[i].name, "index.html") )
                 {
                     if ( host_id == 0 )
-                        M_index_present = i;
+                        M_index_html_present = i;
 #ifdef NPP_MULTI_HOST
                     else
-                        G_hosts[host_id].index_present = i;
+                        G_hosts[host_id].index_html_present = i;
 #endif
                 }
+#ifdef NPP_PHP
+                else if ( 0==strcmp(M_statics[i].name, "index.php") )
+                {
+                    if ( host_id == 0 )
+                        M_index_php_present = i;
+#ifdef NPP_MULTI_HOST
+                    else
+                        G_hosts[host_id].index_php_present = i;
+#endif
+                }
+#endif  /* NPP_PHP */
             }
 
             /* compress ---------------------------------------- */
@@ -4582,6 +4609,8 @@ static bool read_resources(bool first_scan)
     if ( first_scan )
         DBG("Reading res OK");
 
+    /* ------------------------------------------------------------ */
+
     if ( !read_files("", 0, "resmin", STATIC_SOURCE_RESMIN, first_scan, NULL) )
     {
         ERR("Reading resmin failed");
@@ -4590,6 +4619,23 @@ static bool read_resources(bool first_scan)
 
     if ( first_scan )
         DBG("Reading resmin OK");
+
+    /* ------------------------------------------------------------ */
+
+#ifdef NPP_PHP
+
+/*    if ( !read_files("", 0, "php", STATIC_SOURCE_PHP, first_scan, NULL) )
+    {
+        ERR("Reading php failed");
+        return FALSE;
+    }
+
+    if ( first_scan )
+        DBG("Reading php OK"); */
+
+#endif  /* NPP_PHP */
+
+    /* ------------------------------------------------------------ */
 
     if ( !npp_lib_read_snippets("", 0, "snippets", first_scan, NULL) )
     {
@@ -4600,6 +4646,7 @@ static bool read_resources(bool first_scan)
     if ( first_scan )
         DBG("Reading snippets OK");
 
+    /* ------------------------------------------------------------ */
 
 #ifdef NPP_MULTI_HOST   /* side gigs */
 
@@ -4616,6 +4663,8 @@ static bool read_resources(bool first_scan)
         if ( first_scan )
             DBG("Reading %s's res OK", G_hosts[i].host);
 
+        /* ------------------------------------------------------------ */
+
         if ( G_hosts[i].resmin[0] && !read_files(G_hosts[i].host, i, G_hosts[i].resmin, STATIC_SOURCE_RESMIN, first_scan, NULL) )
         {
             ERR("Reading %s's resmin failed", G_hosts[i].host);
@@ -4624,6 +4673,23 @@ static bool read_resources(bool first_scan)
 
         if ( first_scan )
             DBG("Reading %s's resmin OK", G_hosts[i].host);
+
+        /* ------------------------------------------------------------ */
+
+#ifdef NPP_PHP
+
+/*        if ( G_hosts[i].php[0] && !read_files(G_hosts[i].host, i, G_hosts[i].php, STATIC_SOURCE_PHP, first_scan, NULL) )
+        {
+            ERR("Reading %s's php failed", G_hosts[i].host);
+            return FALSE;
+        }
+
+        if ( first_scan )
+            DBG("Reading %s's php OK", G_hosts[i].host); */
+
+#endif  /* NPP_PHP */
+
+        /* ------------------------------------------------------------ */
 
         if ( G_hosts[i].snippets[0] && !npp_lib_read_snippets(G_hosts[i].host, i, G_hosts[i].snippets, first_scan, NULL) )
         {
@@ -4637,9 +4703,13 @@ static bool read_resources(bool first_scan)
 
 #endif  /* NPP_MULTI_HOST */
 
+    /* ------------------------------------------------------------ */
+
     qsort(&M_statics, M_statics_cnt, sizeof(M_statics[0]), compare_statics);
 
     qsort(&G_snippets, G_snippets_cnt, sizeof(G_snippets[0]), lib_compare_snippets);
+
+    /* ------------------------------------------------------------ */
 
     return TRUE;
 }
@@ -4665,12 +4735,19 @@ static int is_static_res()
         }
         else if ( M_statics[middle].host_id == G_connections[G_ci].host_id )
         {
-            result = strcmp(M_statics[middle].name, G_connections[G_ci].uri);
+            result = strcmp(M_statics[middle].name, G_connections[G_ci].uri_no_qs);
 
             if ( result < 0 )
                 first = middle + 1;
             else if ( result == 0 )
             {
+#ifdef NPP_PHP
+                if ( M_statics[middle].type == NPP_CONTENT_TYPE_PHP )
+                {
+                    G_connections[G_ci].php = TRUE;
+                    return -1;
+                }
+#endif
                 if ( G_connections[G_ci].if_mod_since >= M_statics[middle].modified )
                     G_connections[G_ci].status = 304;  /* Not Modified */
 
@@ -4691,12 +4768,19 @@ static int is_static_res()
 
     while ( first <= last )
     {
-        result = strcmp(M_statics[middle].name, G_connections[G_ci].uri);
+        result = strcmp(M_statics[middle].name, G_connections[G_ci].uri_no_qs);
 
         if ( result < 0 )
             first = middle + 1;
         else if ( result == 0 )
         {
+#ifdef NPP_PHP
+            if ( M_statics[middle].type == NPP_CONTENT_TYPE_PHP )
+            {
+                G_connections[G_ci].php = TRUE;
+                return -1;
+            }
+#endif
             if ( G_connections[G_ci].if_mod_since >= M_statics[middle].modified )
                 G_connections[G_ci].status = 304;  /* Not Modified */
 
@@ -4756,10 +4840,21 @@ static void process_request()
     /* ------------------------------------------------------------------------ */
     /* Generate HTML content before header -- to know its size & type --------- */
 
+    bool fresh_session=FALSE;
+
+#ifdef NPP_PHP
+
+    if ( G_connections[G_ci].php )
+    {
+        process_php();
+    }
+    else
+    {
+
+#endif  /* NPP_PHP */
+
     /* ------------------------------------------------------------------------ */
     /* authorization check / log in from cookies ------------------------------ */
-
-    bool fresh_session=FALSE;
 
 #ifdef NPP_USERS
 
@@ -4892,6 +4987,10 @@ static void process_request()
         }
     }
 
+#ifdef NPP_PHP
+    }
+#endif
+
     /* ------------------------------------------------------------------------ */
 
     G_connections[G_ci].last_activity = G_now;
@@ -4954,6 +5053,108 @@ static void process_request()
         RES_DONT_CACHE;
     }
 }
+
+
+#ifdef NPP_PHP
+/* --------------------------------------------------------------------------
+   PHP request processing
+-------------------------------------------------------------------------- */
+static void process_php()
+{
+    DBG("process_php");
+
+    char *qs = strchr(G_connections[G_ci].uri, '?');
+
+    char cmd[4096];
+
+    STRM_BEGIN(cmd);
+
+    if ( NPP_CONN_IS_PAYLOAD(G_connections[G_ci].flags) && G_connections[G_ci].clen > 0 && G_connections[G_ci].clen < 3072 )
+    {
+        STRM("echo \"%s\" | ", npp_filter_qs(G_connections[G_ci].in_data));
+    }
+
+    STRM("REDIRECT_STATUS=CGI ");
+    STRM("SCRIPT_FILENAME=%s/res/%s ", G_appdir, G_connections[G_ci].uri_no_qs);
+    STRM("REQUEST_METHOD=%s ", G_connections[G_ci].method);
+
+    if ( REQ_GET && qs && *(qs+1) != EOS )
+    {
+        STRM("QUERY_STRING=\"%s\" ", npp_filter_qs(qs+1));
+        STRM("CONTENT_LENGTH=%d ", strlen(qs+1));
+        STRM("CONTENT_TYPE=application/www-form-urlencoded ");
+    }
+    else if ( NPP_CONN_IS_PAYLOAD(G_connections[G_ci].flags) && G_connections[G_ci].clen > 0 && G_connections[G_ci].clen < 3072 )
+    {
+        STRM("CONTENT_LENGTH=%d ", G_connections[G_ci].clen);
+
+        if ( G_connections[G_ci].in_ctypestr[0] )
+            STRM("CONTENT_TYPE=%s ", G_connections[G_ci].in_ctypestr);
+        else
+            STRM("CONTENT_TYPE=application/www-form-urlencoded ");
+    }
+
+    STRM("php-cgi");
+    STRM_END;
+
+    DBG("Executing [%s]...", cmd);
+
+    FILE *pipe = popen(cmd, "r");
+
+    if ( !pipe )
+    {
+        ERR("Couldn't execute php-cgi");
+        RES_STATUS(500);
+        return;
+    }
+
+    /* read the HTTP response header */
+
+    char line[2048];
+    int  len;
+
+    while ( fgets(line, 2047, pipe) )
+    {
+        len = strlen(line);
+
+        while ( len && (line[len-1]=='\n' || line[len-1]=='\r' || line[len-1]==' ' || line[len-1]=='.') )
+        {
+            line[len-1] = EOS;
+            len--;
+        }
+
+        DDBG("line [%s]", line);
+
+        if ( line[0] == EOS )   /* end of header */
+        {
+            DDBG("empty line, breaking");
+            break;
+        }
+
+        if ( (line[0]=='L' || line[0]=='l') && 0==strncmp(line+1, "ocation:", 8) )
+        {
+            DBG("Redirecting to [%s]", line+10);
+            RES_LOCATION(line+10);
+        }
+    }
+
+    /* read the body */
+
+static char buffer[NPP_OUT_BUFSIZE+1];
+
+    memset(buffer, 0, NPP_OUT_BUFSIZE);   /* we'll not have EOS from fread */
+
+    fread(buffer, NPP_OUT_BUFSIZE, 1, pipe);
+
+    OUT(buffer);
+
+#ifdef NPP_DEBUG
+    npp_log_long(buffer, strlen(buffer), "PHP output");
+#endif
+
+    pclose(pipe);
+}
+#endif  /* NPP_PHP */
 
 
 /* --------------------------------------------------------------------------
@@ -5944,6 +6145,9 @@ static void reset_connection(int ci, char new_state)
     }
 
     G_connections[ci].static_res = NPP_NOT_STATIC;
+#ifdef NPP_PHP
+    G_connections[ci].php = FALSE;
+#endif
     G_connections[ci].out_ctype = NPP_CONTENT_TYPE_HTML;
     G_connections[ci].ctypestr[0] = EOS;
     G_connections[ci].cdisp[0] = EOS;
@@ -6225,6 +6429,8 @@ static int parse_request(int len)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
 
+    bool end_of_uri_no_qs = FALSE;
+
     for ( i; i<hlen; ++i )   /* URI */
     {
 
@@ -6233,7 +6439,19 @@ static int parse_request(int len)
         if ( G_connections[G_ci].in[i] != ' ' && G_connections[G_ci].in[i] != '\t' )
         {
             if ( j < NPP_MAX_URI_LEN )
-                G_connections[G_ci].uri[j++] = G_connections[G_ci].in[i];
+            {
+                G_connections[G_ci].uri[j] = G_connections[G_ci].in[i];
+
+                if ( G_connections[G_ci].in[i] == '?' )
+                {
+                    G_connections[G_ci].uri_no_qs[j] = EOS;
+                    end_of_uri_no_qs = TRUE;
+                }
+                else if ( !end_of_uri_no_qs )
+                    G_connections[G_ci].uri_no_qs[j] = G_connections[G_ci].in[i];
+
+                ++j;
+            }
             else
             {
                 WAR("URI too long, ignoring");
@@ -6251,6 +6469,7 @@ static int parse_request(int len)
         else    /* end of URI */
         {
             G_connections[G_ci].uri[j] = EOS;
+            G_connections[G_ci].uri_no_qs[j] = EOS;
             break;
         }
     }
@@ -6283,7 +6502,8 @@ static int parse_request(int len)
     }
 #endif  /* NPP_ROOT_URI */
 
-    DDBG("URI [%s]", G_connections[G_ci].uri);
+    DDBG("      URI [%s]", G_connections[G_ci].uri);
+    DDBG("uri_no_qs [%s]", G_connections[G_ci].uri_no_qs);
 
     i += 6;   /* skip the space and HTTP/ */
 
@@ -6421,17 +6641,31 @@ static int parse_request(int len)
 
     if ( G_connections[G_ci].uri[0]==EOS && REQ_GET )
     {
-        DBG("M_index_present = %d", M_index_present);
+        DBG("M_index_html_present = %d", M_index_html_present);
 
 #ifdef NPP_MULTI_HOST
-        if ( (G_connections[G_ci].host_id==0 && M_index_present!=-1) || G_hosts[G_connections[G_ci].host_id].index_present != -1 )
+        if ( (G_connections[G_ci].host_id==0 && M_index_html_present!=-1) || G_hosts[G_connections[G_ci].host_id].index_html_present != -1 )
 #else
-        if ( M_index_present != -1 )
+        if ( M_index_html_present != -1 )
 #endif
         {
             INF("Serving index.html");
             strcpy(G_connections[G_ci].uri, "index.html");
         }
+
+#ifdef NPP_PHP
+        DBG("M_index_php_present = %d", M_index_php_present);
+
+#ifdef NPP_MULTI_HOST
+        if ( (G_connections[G_ci].host_id==0 && M_index_php_present!=-1) || G_hosts[G_connections[G_ci].host_id].index_php_present != -1 )
+#else
+        if ( M_index_php_present != -1 )
+#endif
+        {
+            INF("Serving index.php");
+            strcpy(G_connections[G_ci].uri, "index.php");
+        }
+#endif  /* NPP_PHP */
     }
 
 #endif  /* NPP_DONT_LOOK_FOR_INDEX */
@@ -7092,13 +7326,13 @@ static int set_http_req_val(const char *label, const char *value)
 
         int len = strlen(value);
 
-        if ( len > 15 && 0==strncmp(uvalue, "APPLICATION/JSON", 16) )
-        {
-            G_connections[G_ci].in_ctype = NPP_CONTENT_TYPE_JSON;
-        }
-        else if ( len > 32 && 0==strncmp(uvalue, "APPLICATION/X-WWW-FORM-URLENCODED", 33) )
+        if ( len > 32 && 0==strncmp(uvalue, "APPLICATION/X-WWW-FORM-URLENCODED", 33) )
         {
             G_connections[G_ci].in_ctype = NPP_CONTENT_TYPE_URLENCODED;
+        }
+        else if ( len > 15 && 0==strncmp(uvalue, "APPLICATION/JSON", 16) )
+        {
+            G_connections[G_ci].in_ctype = NPP_CONTENT_TYPE_JSON;
         }
         else if ( len > 18 && 0==strncmp(uvalue, "MULTIPART/FORM-DATA", 19) )
         {
@@ -7113,6 +7347,10 @@ static int set_http_req_val(const char *label, const char *value)
         else if ( len > 23 && 0==strncmp(uvalue, "APPLICATION/OCTET-STREAM", 24) )
         {
             G_connections[G_ci].in_ctype = NPP_CONTENT_TYPE_OCTET_STREAM;
+        }
+        else    /* do not allow (CGI safety) */
+        {
+            G_connections[G_ci].in_ctypestr[0] = EOS;
         }
     }
     else if ( 0==strcmp(ulabel, "AUTHORIZATION") )
@@ -7935,12 +8173,23 @@ void npp_add_to_static_res(const char *host, const char *name, const char *src)
     if ( 0==strcmp(M_statics[M_statics_cnt].name, "index.html") )
     {
         if ( M_statics[M_statics_cnt].host_id == 0 )
-            M_index_present = M_statics_cnt;
+            M_index_html_present = M_statics_cnt;
 #ifdef NPP_MULTI_HOST
         else
-            G_hosts[M_statics[M_statics_cnt].host_id].index_present = M_statics_cnt;
+            G_hosts[M_statics[M_statics_cnt].host_id].index_html_present = M_statics_cnt;
 #endif
     }
+#ifdef NPP_PHP
+    else if ( 0==strcmp(M_statics[M_statics_cnt].name, "index.php") )
+    {
+        if ( M_statics[M_statics_cnt].host_id == 0 )
+            M_index_php_present = M_statics_cnt;
+#ifdef NPP_MULTI_HOST
+        else
+            G_hosts[M_statics[M_statics_cnt].host_id].index_php_present = M_statics_cnt;
+#endif
+    }
+#endif  /* NPP_PHP */
 
     /* compress ---------------------------------------- */
 

--- a/lib/npp_lib.c
+++ b/lib/npp_lib.c
@@ -3127,6 +3127,28 @@ bool npp_add_host(const char *host, const char *res, const char *resmin, const c
 
 
 /* --------------------------------------------------------------------------
+   Dispatcher logic
+-------------------------------------------------------------------------- */
+#ifdef NPP_CPP_STRINGS
+bool npp_lib_req(const std::string& res_)
+{
+    const char *res = res_.c_str();
+#else
+bool npp_lib_req(const char *res)
+{
+#endif
+    const char *p;
+
+    if ( res[0] == '/' )
+        p = res + 1;
+    else
+        p = res;
+
+    return (0==strcmp(G_connections[G_ci].resource, p));
+}
+
+
+/* --------------------------------------------------------------------------
    Get the incoming param if Content-Type == JSON
 -------------------------------------------------------------------------- */
 static bool get_qs_param_json(const char *name, char *retbuf, int maxlen)

--- a/lib/npp_lib.c
+++ b/lib/npp_lib.c
@@ -3089,16 +3089,30 @@ static int compare_hosts(const void *a, const void *b)
    Add a host and assign resource directories
 -------------------------------------------------------------------------- */
 #ifdef NPP_CPP_STRINGS
+//#ifdef NPP_PHP
+//bool npp_add_host(const std::string& host_, const std::string& res_, const std::string& resmin_, const std::string& snippets_, const std::string& php_, char required_auth_level)
+//{
+//#else
 bool npp_add_host(const std::string& host_, const std::string& res_, const std::string& resmin_, const std::string& snippets_, char required_auth_level)
 {
+//#endif
     const char *host = host_.c_str();
     const char *res = res_.c_str();
     const char *resmin = resmin_.c_str();
     const char *snippets = snippets_.c_str();
+//#ifdef NPP_PHP
+//    const char *php = php_.c_str();
+//#endif
 #else
+//#ifdef NPP_PHP
+//bool npp_add_host(const char *host, const char *res, const char *resmin, const char *snippets, const char *php, char required_auth_level)
+//{
+//#else
 bool npp_add_host(const char *host, const char *res, const char *resmin, const char *snippets, char required_auth_level)
 {
+//#endif
 #endif
+
 #ifdef NPP_MULTI_HOST
 
     if ( G_hosts_cnt >= NPP_MAX_HOSTS ) return FALSE;
@@ -3111,10 +3125,17 @@ bool npp_add_host(const char *host, const char *res, const char *resmin, const c
         COPY(G_hosts[G_hosts_cnt].resmin, resmin, 255);
     if ( snippets && snippets[0] )
         COPY(G_hosts[G_hosts_cnt].snippets, snippets, 255);
+//#ifdef NPP_PHP
+//    if ( php && php[0] )
+//        COPY(G_hosts[G_hosts_cnt].php, php, 255);
+//#endif
 
     G_hosts[G_hosts_cnt].required_auth_level = required_auth_level;
 
-    G_hosts[G_hosts_cnt].index_present = -1;
+    G_hosts[G_hosts_cnt].index_html_present = -1;
+#ifdef NPP_PHP
+    G_hosts[G_hosts_cnt].index_php_present = -1;
+#endif
 
     ++G_hosts_cnt;
 
@@ -6345,6 +6366,43 @@ static char dst[NPP_LIB_STR_BUF];
 
 
 /* --------------------------------------------------------------------------
+   Filter everything but query string-allowed chars
+---------------------------------------------------------------------------*/
+#ifdef NPP_CPP_STRINGS
+char *npp_filter_qs(const std::string& src_)
+{
+    const char *src = src_.c_str();
+#else
+char *npp_filter_qs(const char *src)
+{
+#endif
+static char dst[NPP_LIB_STR_BUF];
+    int     i=0, j=0;
+
+    while ( src[i] && j<NPP_LIB_STR_CHECK )
+    {
+        if ( (src[i] >= 65 && src[i] <= 90)
+                || (src[i] >= 97 && src[i] <= 122)
+                || isdigit(src[i])
+                || src[i] == '.'
+                || src[i] == '+'
+                || src[i] == '-'
+                || src[i] == '_'
+                || src[i] == '='
+                || src[i] == '&'
+                || src[i] == '%' )
+            dst[j++] = src[i];
+
+        ++i;
+    }
+
+    dst[j] = EOS;
+
+    return dst;
+}
+
+
+/* --------------------------------------------------------------------------
    Add spaces to make string to have len length
 -------------------------------------------------------------------------- */
 #ifdef NPP_CPP_STRINGS
@@ -6512,6 +6570,8 @@ char npp_lib_get_res_type(const char *fname)
         return NPP_CONTENT_TYPE_ICO;
     else if ( 0==strcmp(uext, "PNG") )
         return NPP_CONTENT_TYPE_PNG;
+    else if ( 0==strcmp(uext, "PHP") )
+        return NPP_CONTENT_TYPE_PHP;
     else if ( 0==strcmp(uext, "WOFF2") )
         return NPP_CONTENT_TYPE_WOFF2;
     else if ( 0==strcmp(uext, "SVG") )

--- a/lib/npp_lib.c
+++ b/lib/npp_lib.c
@@ -6403,6 +6403,39 @@ static char dst[NPP_LIB_STR_BUF];
 
 
 /* --------------------------------------------------------------------------
+   Filter everything but cookie session chars
+---------------------------------------------------------------------------*/
+#ifdef NPP_CPP_STRINGS
+char *npp_filter_cookie(const std::string& src_)
+{
+    const char *src = src_.c_str();
+#else
+char *npp_filter_cookie(const char *src)
+{
+#endif
+static char dst[NPP_LIB_STR_BUF];
+    int     i=0, j=0;
+
+    while ( src[i] && j<NPP_LIB_STR_CHECK )
+    {
+        if ( (src[i] >= 65 && src[i] <= 90)
+                || (src[i] >= 97 && src[i] <= 122)
+                || isdigit(src[i])
+                || src[i] == '='
+                || src[i] == ';'
+                || src[i] == ' ' )
+            dst[j++] = src[i];
+
+        ++i;
+    }
+
+    dst[j] = EOS;
+
+    return dst;
+}
+
+
+/* --------------------------------------------------------------------------
    Add spaces to make string to have len length
 -------------------------------------------------------------------------- */
 #ifdef NPP_CPP_STRINGS

--- a/lib/npp_lib.h
+++ b/lib/npp_lib.h
@@ -705,6 +705,12 @@ extern "C" {
 #endif
 
 #ifdef NPP_CPP_STRINGS
+    char *npp_filter_qs(const std::string& src);
+#else
+    char *npp_filter_qs(const char *src);
+#endif
+
+#ifdef NPP_CPP_STRINGS
     char *npp_add_spaces(const std::string& src, int new_len);
 #else
     char *npp_add_spaces(const char *src, int new_len);
@@ -842,9 +848,17 @@ extern "C" {
 #endif
 
 #ifdef NPP_CPP_STRINGS
-    bool npp_add_host(const std::string& host, const std::string& res, const std::string& resmin, const std::string& snippets, char required_auth_level);
+//    #ifdef NPP_PHP
+//        bool npp_add_host(const std::string& host, const std::string& res, const std::string& resmin, const std::string& snippets, const std::string& php, char required_auth_level);
+//    #else
+        bool npp_add_host(const std::string& host, const std::string& res, const std::string& resmin, const std::string& snippets, char required_auth_level);
+//    #endif
 #else
-    bool npp_add_host(const char *host, const char *res, const char *resmin, const char *snippets, char required_auth_level);
+//    #ifdef NPP_PHP
+//        bool npp_add_host(const char *host, const char *res, const char *resmin, const char *snippets, const char *php, char required_auth_level);
+//    #else
+        bool npp_add_host(const char *host, const char *res, const char *resmin, const char *snippets, char required_auth_level);
+//    #endif
 #endif
 
 #ifdef NPP_CPP_STRINGS

--- a/lib/npp_lib.h
+++ b/lib/npp_lib.h
@@ -109,6 +109,8 @@
 #define NPP_ESC_SQL                     '1'
 #define NPP_ESC_HTML                    '2'
 
+#define REQ(res)                        npp_lib_req(res)
+
 #define QS_DONT_ESCAPE(param, val)      npp_lib_get_qs_param(param, val, MAX_URI_VAL_LEN, NPP_ESC_NONE)
 #define QS_SQL_ESCAPE(param, val)       npp_lib_get_qs_param(param, val, MAX_URI_VAL_LEN, NPP_ESC_SQL)
 #define QS_HTML_ESCAPE(param, val)      npp_lib_get_qs_param(param, val, MAX_URI_VAL_LEN, NPP_ESC_HTML)
@@ -1032,6 +1034,12 @@ const unsigned char *npp_binstr(const unsigned char *data, size_t data_len, cons
     void npp_out_html_footer();
     void npp_append_css(const char *fname, bool first);
     void npp_append_script(const char *fname, bool first);
+
+#ifdef NPP_CPP_STRINGS
+    bool npp_lib_req(const std::string& res);
+#else
+    bool npp_lib_req(const char *res);
+#endif
 
     bool npp_lib_get_qs_param(const char *name, char *retbuf, size_t maxlen, char esc_type);
     const unsigned char *npp_lib_get_qs_param_multipart(const char *name, size_t *retlen, char *retfname);

--- a/lib/npp_lib.h
+++ b/lib/npp_lib.h
@@ -711,6 +711,12 @@ extern "C" {
 #endif
 
 #ifdef NPP_CPP_STRINGS
+    char *npp_filter_cookie(const std::string& src);
+#else
+    char *npp_filter_cookie(const char *src);
+#endif
+
+#ifdef NPP_CPP_STRINGS
     char *npp_add_spaces(const std::string& src, int new_len);
 #else
     char *npp_add_spaces(const char *src, int new_len);

--- a/resmin/npp.css
+++ b/resmin/npp.css
@@ -20,7 +20,7 @@
 {
     font-size: 12pt;
     background-color: white;
-    padding: 3px 12px 13px 14px;
+    padding: 6px 14px 14px 14px;
     box-shadow: 4px 4px 16px 0px rgba(0,0,0,0.2);
     border: 1px solid #bbbbbb;
     z-index: 1000;

--- a/resmin/npp.js
+++ b/resmin/npp.js
@@ -106,7 +106,7 @@ function center(d)
 // Create modal window
 // l1 = first line
 // l2 = second line
-// w = width (em)
+// w = width (em), optional, default = 23
 // --------------------------------------------------------------------------
 function mw(l1, l2, w)
 {
@@ -115,7 +115,7 @@ function mw(l1, l2, w)
     if ( w )
         d.style.width = w + "em";
     else
-        d.style.width = "20em";
+        d.style.width = "23em";
 
     d.className = "mw";
     d.id = "mw";
@@ -123,7 +123,7 @@ function mw(l1, l2, w)
     let s1 = document.createElement("span");
 
     s1.innerHTML = "<div style=\"display:flex;\">"
-        + "<span style=\"width:92%;margin-top:6px;\">" + l1 + "</span>"
+        + "<span style=\"width:92%;margin-top:12px;margin-left:11px;\">" + l1 + "</span>"
         + "<div style=\"width:8%;text-align:right;\"><span style=\"font-size:1.5em;cursor:pointer;\" onClick=\"mw_off();\">&#10005;</span></div>"
         + "</div><br>";
 


### PR DESCRIPTION
## New

* REQ() is now forward slash-agnostic
* URI() accepting std::string
* NPP_PHP macro. If defined, php files in res – if requested – are passed to php-cgi. It allows to execute PHP code straight from the resource directory. PHP code does not share Node++ sessions. Query strings, POST payload and cookies are passed over to php-cgi and likewise, cookies and redirections are passed back to the client. It's designed to enable quick and simple PHP support. Therefore the request payload is limited to 3 KiB and rendered response to NPP_OUT_BUFSIZE bytes, which is 128 KiB by default (NPP_MEM_SMALL).

### NPP_PHP security considerations

* The request is passed over to php-cgi only after confirming the requested php file exists in res directory.
* By default, the PHPSESSID is the only cookie allowed and is sanitized using npp_filter_strict() before passing over to php-cgi. To enable passing all cookies, add NPP_PHP_ALL_COOKIES.
* Query string and payload is sanitized using npp_filter_qs(). It practically means the only Content-type fully supported by NPP_PHP is www-form-urlencoded. Due to the way payload is passed to php-cgi, without this sanitization, the system would be open to shell attacks.
